### PR TITLE
Logo shinified, site title changed

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -17,7 +17,7 @@
   align-items: center;
   .logo {
     border: solid 1.5px $orange;
-    background-image: linear-gradient(to left, $light-orange, $light-red 50% 50%, $light-orange);
+    background-image: linear-gradient(to left, $light-orange, white 50%, $light-orange);
     font-family: $logo-font;
     font-size: 1.5em;
     padding: ($spacer / 4) $spacer;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Lft</title>
+    <title>LFT: Looking for Tutor</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
This PR makes the logo shinier, and changes the site's title (as shown on browser tabs) to "LFT: Looking for Tutor".

<img width="270" alt="image" src="https://user-images.githubusercontent.com/80717525/171623630-f35df247-01bf-4514-8eaa-0491b33d13fd.png">
