### PR TITLE
Restored centered text in banner

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -20,9 +20,11 @@
     font-weight: bold;
     font-family: $headers-font;
     letter-spacing: 2px;
+    text-align: center;
   }
   p {
     font-size: 1.5em;
+    text-align: center;
   }
   .banner-child:last-child {
     // Hacky fix for now


### PR DESCRIPTION
Feel compelled to fix this as I didn't notice it until I was pitching, and now I can't un-see it.